### PR TITLE
AI assistant: dish create/update via confirm-before-save proposals

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -23,6 +23,7 @@ import {AutoClockOutProvider} from "@/providers/auto-clock-out.provider.tsx";
 import {I18nProvider} from "@/providers/i18n.provider.tsx";
 import {AppRoutes} from "@/routes/app.routes.tsx";
 import {IntegrationProvider} from "@/providers/integration.provider.tsx";
+import {AiAssistantWidget} from "@/components/ai-assistant/assistant-widget.tsx";
 
 
 // react query client wrapper
@@ -70,6 +71,7 @@ function App() {
                             <SessionIdleProvider>
                               <AutoClockOutProvider>
                                 <GlobalDeliveryOrderPopup/>
+                                <AiAssistantWidget/>
                                 <AppRoutes/>
                               </AutoClockOutProvider>
                             </SessionIdleProvider>

--- a/src/components/ai-assistant/assistant-widget.tsx
+++ b/src/components/ai-assistant/assistant-widget.tsx
@@ -1,0 +1,237 @@
+import {useMemo, useState} from "react";
+import {useTranslation} from "react-i18next";
+import {useAtom} from "jotai";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faComments, faTimes, faSpinner} from "@fortawesome/free-solid-svg-icons";
+import {useDB} from "@/api/db/db.ts";
+import {appPage} from "@/store/jotai.ts";
+import {Button} from "@/components/common/input/button.tsx";
+import {Textarea} from "@/components/common/input/textarea.tsx";
+import type {OpenAIChatMessage} from "@/lib/openai.service.ts";
+import {
+  resumeAiAssistantAgent,
+  runAiAssistantAgent,
+  type AssistantAgentResult,
+  type AssistantDbClient,
+} from "@/lib/ai/assistant-agent.ts";
+import {commitWriteProposal} from "@/lib/ai/write-executor.ts";
+import type {WriteProposal} from "@/lib/ai/tools/write-tools.ts";
+import {WriteProposalPreview} from "@/components/ai-assistant/write-proposal-preview.tsx";
+
+type DisplayEntry = {role: "user" | "assistant" | "system"; content: string};
+
+type PendingProposal = {
+  proposal: WriteProposal;
+  toolCallId: string;
+};
+
+/**
+ * Global floating assistant — mounted once in app.tsx next to
+ * GlobalDeliveryOrderPopup, available from any screen. Old Reports > AI
+ * (screens/reports/ai.report.tsx) is untouched and still works as a
+ * read-only fallback; this widget adds dish write capability on top of the
+ * same read tools via assistant-agent.ts.
+ */
+export function AiAssistantWidget() {
+  const {t} = useTranslation(["admin", "common", "toast"]);
+  const [{user}] = useAtom(appPage);
+  const db = useDB() as unknown as AssistantDbClient;
+
+  const [open, setOpen] = useState(false);
+  const [prompt, setPrompt] = useState("");
+  const [entries, setEntries] = useState<DisplayEntry[]>([]);
+  const [history, setHistory] = useState<OpenAIChatMessage[]>([]);
+  const [pending, setPending] = useState<PendingProposal | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allowedModules = useMemo(() => {
+    const roles = user?.user_role?.roles ?? user?.role?.roles ?? [];
+    return Array.isArray(roles) ? (roles as string[]) : [];
+  }, [user?.user_role?.roles, user?.role?.roles]);
+
+  const applyResult = (result: AssistantAgentResult) => {
+    setHistory(result.messages);
+    if (result.type === "answer") {
+      setEntries(prev => [...prev, {role: "assistant", content: result.answer}]);
+      setPending(null);
+    } else {
+      setPending({proposal: result.proposal, toolCallId: result.toolCallId});
+      setEntries(prev => [
+        ...prev,
+        {
+          role: "assistant",
+          content: t("aiAssistant.reviewPrompt", {
+            defaultValue: `I've prepared ${result.proposal.records.length} ${result.proposal.entityLabel.toLowerCase()} change(s) for you to review below.`,
+          }),
+        },
+      ]);
+    }
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || loading) return;
+
+    setEntries(prev => [...prev, {role: "user", content: trimmed}]);
+    setPrompt("");
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await runAiAssistantAgent(db, t, trimmed, {allowedModules}, history);
+      applyResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!pending || loading) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const summary = await commitWriteProposal(db, t, pending.proposal);
+      setEntries(prev => [
+        ...prev,
+        {
+          role: "system",
+          content: t("aiAssistant.applied", {
+            defaultValue: `Applied: ${summary.imported} created/updated, ${summary.failed} failed, ${summary.skipped} skipped.`,
+          }),
+        },
+      ]);
+      const result = await resumeAiAssistantAgent(
+        db, t, history, pending.toolCallId, {confirmed: true, summary}, {allowedModules},
+      );
+      setPending(null);
+      applyResult(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      try {
+        const result = await resumeAiAssistantAgent(
+          db, t, history, pending.toolCallId, {confirmed: false, error: message}, {allowedModules},
+        );
+        setPending(null);
+        applyResult(result);
+      } catch {
+        setPending(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!pending || loading) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await resumeAiAssistantAgent(
+        db, t, history, pending.toolCallId,
+        {confirmed: false, error: t("aiAssistant.cancelled", {defaultValue: "User cancelled this change."})},
+        {allowedModules},
+      );
+      setPending(null);
+      applyResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setPending(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-5 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700"
+        aria-label={t("aiAssistant.open", {defaultValue: "Open assistant"})}
+      >
+        <FontAwesomeIcon icon={faComments} />
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-5 right-5 z-40 flex h-[32rem] w-96 flex-col rounded-lg border border-gray-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b border-gray-200 px-3 py-2">
+        <span className="text-sm font-semibold text-gray-800">
+          {t("aiAssistant.title", {defaultValue: "Assistant"})}
+        </span>
+        <button type="button" onClick={() => setOpen(false)} aria-label={t("common:close", {defaultValue: "Close"})}>
+          <FontAwesomeIcon icon={faTimes} className="text-gray-500" />
+        </button>
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto px-3 py-2">
+        {entries.map((entry, i) => (
+          <div
+            key={i}
+            className={`text-sm ${entry.role === "user" ? "text-right" : "text-left"}`}
+          >
+            <span
+              className={`inline-block rounded-md px-2 py-1 ${
+                entry.role === "user"
+                  ? "bg-blue-600 text-white"
+                  : entry.role === "system"
+                    ? "bg-gray-100 text-gray-600 italic"
+                    : "bg-gray-100 text-gray-800"
+              }`}
+            >
+              {entry.content}
+            </span>
+          </div>
+        ))}
+
+        {pending && (
+          <div className="space-y-2">
+            <WriteProposalPreview proposal={pending.proposal} />
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" size="sm" onClick={handleCancel} disabled={loading}>
+                {t("common:cancel", {defaultValue: "Cancel"})}
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleConfirm}
+                disabled={loading || pending.proposal.hasBlockingErrors && pending.proposal.records.every(r => r.issues.some(i => i.severity === "error"))}
+              >
+                {t("aiAssistant.confirm", {defaultValue: "Confirm"})}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && <div className="text-xs text-red-600">{error}</div>}
+      </div>
+
+      <div className="flex items-end gap-2 border-t border-gray-200 p-2">
+        <Textarea
+          value={prompt}
+          onChange={(e: any) => setPrompt(e.target.value)}
+          onKeyDown={(e: any) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          placeholder={t("aiAssistant.placeholder", {defaultValue: "Ask about sales, or ask to add/update a dish…"})}
+          rows={2}
+          disabled={loading}
+          className="flex-1"
+        />
+        <Button variant="primary" size="sm" onClick={handleSubmit} disabled={loading || !prompt.trim()}>
+          {loading ? <FontAwesomeIcon icon={faSpinner} spin /> : t("common:send", {defaultValue: "Send"})}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai-assistant/assistant-widget.tsx
+++ b/src/components/ai-assistant/assistant-widget.tsx
@@ -7,6 +7,7 @@ import {useDB} from "@/api/db/db.ts";
 import {appPage} from "@/store/jotai.ts";
 import {Button} from "@/components/common/input/button.tsx";
 import {Textarea} from "@/components/common/input/textarea.tsx";
+import {Modal} from "@/components/common/react-aria/modal.tsx";
 import type {OpenAIChatMessage} from "@/lib/openai.service.ts";
 import {
   resumeAiAssistantAgent,
@@ -152,7 +153,7 @@ export function AiAssistantWidget() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="fixed bottom-5 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700"
+        className="fixed bottom-5 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-white shadow-lg hover:bg-primary-600"
         aria-label={t("aiAssistant.open", {defaultValue: "Open assistant"})}
       >
         <FontAwesomeIcon icon={faComments} />
@@ -180,7 +181,7 @@ export function AiAssistantWidget() {
             <span
               className={`inline-block rounded-md px-2 py-1 ${
                 entry.role === "user"
-                  ? "bg-blue-600 text-white"
+                  ? "bg-primary-500 text-white"
                   : entry.role === "system"
                     ? "bg-gray-100 text-gray-600 italic"
                     : "bg-gray-100 text-gray-800"
@@ -191,26 +192,7 @@ export function AiAssistantWidget() {
           </div>
         ))}
 
-        {pending && (
-          <div className="space-y-2">
-            <WriteProposalPreview proposal={pending.proposal} />
-            <div className="flex justify-end gap-2">
-              <Button variant="secondary" size="sm" onClick={handleCancel} disabled={loading}>
-                {t("common:cancel", {defaultValue: "Cancel"})}
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleConfirm}
-                disabled={loading || pending.proposal.hasBlockingErrors && pending.proposal.records.every(r => r.issues.some(i => i.severity === "error"))}
-              >
-                {t("aiAssistant.confirm", {defaultValue: "Confirm"})}
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {error && <div className="text-xs text-red-600">{error}</div>}
+        {error && <div className="text-xs text-danger-600">{error}</div>}
       </div>
 
       <div className="flex items-end gap-2 border-t border-gray-200 p-2">
@@ -232,6 +214,30 @@ export function AiAssistantWidget() {
           {loading ? <FontAwesomeIcon icon={faSpinner} spin /> : t("common:send", {defaultValue: "Send"})}
         </Button>
       </div>
+
+      {/* Full-width modal, not squeezed into the 384px chat sidebar — Ahmed was explicit
+          that bulk-edit preview must be full line-by-line, not summarized; a table crammed
+          into the chat panel truncates every column and defeats that requirement. */}
+      {pending && (
+        <Modal open onClose={handleCancel} size="xl" title={t("aiAssistant.reviewTitle", {defaultValue: "Review changes"})}>
+          <div className="space-y-3">
+            <WriteProposalPreview proposal={pending.proposal} />
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" size="sm" onClick={handleCancel} disabled={loading}>
+                {t("common:cancel", {defaultValue: "Cancel"})}
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleConfirm}
+                disabled={loading || (pending.proposal.hasBlockingErrors && pending.proposal.records.every(r => r.issues.some(i => i.severity === "error")))}
+              >
+                {t("aiAssistant.confirm", {defaultValue: "Confirm"})}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/components/ai-assistant/write-proposal-preview.tsx
+++ b/src/components/ai-assistant/write-proposal-preview.tsx
@@ -59,7 +59,7 @@ export function WriteProposalPreview({proposal}: {proposal: WriteProposal}) {
     return (
       <div
         style={style}
-        className={`flex items-center border-b border-gray-100 px-2 text-sm ${hasError ? "bg-red-50" : ""}`}
+        className={`flex items-center border-b border-gray-100 px-2 text-sm ${hasError ? "bg-danger-100" : ""}`}
         title={[...errorMessages, ...warnings].join("; ") || undefined}
       >
         <div className="w-6 shrink-0 text-gray-400">{index + 1}</div>
@@ -69,9 +69,9 @@ export function WriteProposalPreview({proposal}: {proposal: WriteProposal}) {
           </div>
         ))}
         <div className="w-40 shrink-0 truncate text-xs">
-          {hasError && <span className="text-red-600">{errorMessages.join("; ")}</span>}
+          {hasError && <span className="text-danger-600">{errorMessages.join("; ")}</span>}
           {!hasError && warnings.length > 0 && (
-            <span className="text-amber-600">{warnings.join("; ")}</span>
+            <span className="text-warning-600">{warnings.join("; ")}</span>
           )}
         </div>
       </div>
@@ -96,10 +96,11 @@ export function WriteProposalPreview({proposal}: {proposal: WriteProposal}) {
         {Row}
       </FixedSizeList>
       <div className="px-2 py-1.5 bg-gray-50 border-t border-gray-200 text-xs text-gray-600">
-        {proposal.records.length} {proposal.entityLabel.toLowerCase()}
-        {proposal.records.length === 1 ? "" : "s"} · {proposal.mode}
+        {/* "row(s)" pluralizes safely for any entityLabel; naively appending "s" to the
+            label itself breaks for most entities (Dish -> "dishs", Category -> "categorys"). */}
+        {proposal.records.length} {proposal.entityLabel} row{proposal.records.length === 1 ? "" : "s"} · {proposal.mode}
         {errorCount > 0 && (
-          <span className="text-red-600 ml-2">
+          <span className="text-danger-600 ml-2">
             {errorCount} row{errorCount === 1 ? "" : "s"} will be skipped (blocking errors)
           </span>
         )}

--- a/src/components/ai-assistant/write-proposal-preview.tsx
+++ b/src/components/ai-assistant/write-proposal-preview.tsx
@@ -1,0 +1,109 @@
+import {useMemo} from "react";
+import {useTranslation} from "react-i18next";
+import {FixedSizeList} from "react-window";
+import type {ImportRecord} from "@/lib/data-import/types.ts";
+import type {WriteProposal} from "@/lib/ai/tools/write-tools.ts";
+
+const ROW_HEIGHT = 40;
+const VISIBLE_ROWS = 8;
+
+/** Field order/labels shown in the preview table — mirrors dish.import.config.ts's fields. */
+const DISH_COLUMNS: Array<{key: string; label: string}> = [
+  {key: "number", label: "#"},
+  {key: "name", label: "Name"},
+  {key: "categories", label: "Categories"},
+  {key: "price", label: "Price"},
+  {key: "cost", label: "Cost"},
+  {key: "tax", label: "Tax"},
+];
+
+const formatCell = (key: string, value: unknown): string => {
+  if (value === null || value === undefined || value === "") return "—";
+  if (key === "categories" && Array.isArray(value)) {
+    return value
+      .map((ref: any) => (ref?.create ? `${ref.label} (new)` : ref?.label))
+      .filter(Boolean)
+      .join(", ") || "—";
+  }
+  if (key === "tax") {
+    const ref = value as {label?: string; create?: boolean} | null;
+    if (!ref?.label) return "—";
+    return ref.create ? `${ref.label} (new)` : ref.label;
+  }
+  return String(value);
+};
+
+/**
+ * Full line-by-line review of every proposed row — no summarizing, per
+ * Ahmed's explicit ask ("we don't want any surprises and silent updates").
+ * Virtualized (react-window) since bulk edits can be large.
+ */
+export function WriteProposalPreview({proposal}: {proposal: WriteProposal}) {
+  const {t} = useTranslation("common");
+
+  const rowHasError = (record: ImportRecord) => record.issues.some(i => i.severity === "error");
+  const rowWarnings = (record: ImportRecord) =>
+    record.issues.filter(i => i.severity === "warning").map(i => i.message);
+
+  const errorCount = useMemo(
+    () => proposal.records.filter(rowHasError).length,
+    [proposal.records],
+  );
+
+  const Row = ({index, style}: {index: number; style: React.CSSProperties}) => {
+    const record = proposal.records[index];
+    const hasError = rowHasError(record);
+    const warnings = rowWarnings(record);
+    const errorMessages = record.issues.filter(i => i.severity === "error").map(i => i.message);
+
+    return (
+      <div
+        style={style}
+        className={`flex items-center border-b border-gray-100 px-2 text-sm ${hasError ? "bg-red-50" : ""}`}
+        title={[...errorMessages, ...warnings].join("; ") || undefined}
+      >
+        <div className="w-6 shrink-0 text-gray-400">{index + 1}</div>
+        {DISH_COLUMNS.map(col => (
+          <div key={col.key} className="flex-1 truncate pr-2">
+            {formatCell(col.key, record.values[col.key])}
+          </div>
+        ))}
+        <div className="w-40 shrink-0 truncate text-xs">
+          {hasError && <span className="text-red-600">{errorMessages.join("; ")}</span>}
+          {!hasError && warnings.length > 0 && (
+            <span className="text-amber-600">{warnings.join("; ")}</span>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-md overflow-hidden">
+      <div className="flex items-center px-2 py-1.5 bg-gray-50 border-b border-gray-200 text-xs font-medium text-gray-600">
+        <div className="w-6 shrink-0">#</div>
+        {DISH_COLUMNS.map(col => (
+          <div key={col.key} className="flex-1">{col.label}</div>
+        ))}
+        <div className="w-40 shrink-0">{t("aiAssistant.issues", {defaultValue: "Issues"})}</div>
+      </div>
+      <FixedSizeList
+        height={Math.min(proposal.records.length, VISIBLE_ROWS) * ROW_HEIGHT || ROW_HEIGHT}
+        itemCount={proposal.records.length}
+        itemSize={ROW_HEIGHT}
+        width="100%"
+      >
+        {Row}
+      </FixedSizeList>
+      <div className="px-2 py-1.5 bg-gray-50 border-t border-gray-200 text-xs text-gray-600">
+        {proposal.records.length} {proposal.entityLabel.toLowerCase()}
+        {proposal.records.length === 1 ? "" : "s"} · {proposal.mode}
+        {errorCount > 0 && (
+          <span className="text-red-600 ml-2">
+            {errorCount} row{errorCount === 1 ? "" : "s"} will be skipped (blocking errors)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/ai/assistant-agent.ts
+++ b/src/lib/ai/assistant-agent.ts
@@ -1,0 +1,187 @@
+import type {DbClient} from "@/api/reports/shared/types.ts";
+import type {ImportDbLike} from "@/lib/data-import/types.ts";
+import {
+  callOpenAIChat,
+  type AiTask,
+  type OpenAIChatMessage,
+} from "@/lib/openai.service.ts";
+import {executeAiReportTool, type ExecuteToolContext} from "@/lib/ai/tools/executor.ts";
+import {AI_REPORT_TOOLS} from "@/lib/ai/tools/definitions.ts";
+import {filterToolsByPermissions} from "@/lib/ai/tools/permissions.ts";
+import {AI_WRITE_TOOLS, AI_WRITE_TOOL_NAMES} from "@/lib/ai/tools/write-definitions.ts";
+import {filterWriteToolsByPermissions, canUseWriteTool} from "@/lib/ai/tools/write-permissions.ts";
+import {buildWriteProposal, type TFunc, type WriteProposal} from "@/lib/ai/tools/write-tools.ts";
+import {type AiChartSpec, dedupeCharts} from "@/lib/ai/charts.ts";
+
+const MAX_ITERATIONS = 10;
+const WRITE_TOOL_NAME_SET = new Set(AI_WRITE_TOOL_NAMES);
+
+/**
+ * Combined db handle the widget passes in: read tools only ever use `query`
+ * (same as the existing Reports > AI agent's DbClient); write tools need the
+ * fuller useDB() object (query + insert/create/merge) that ImportDbLike
+ * requires. useDB()'s actual return shape already satisfies both — see
+ * api/db/db.ts's `return {query, insert, create: insert, merge, ...}`.
+ */
+export type AssistantDbClient = DbClient & ImportDbLike;
+
+const messageText = (content: OpenAIChatMessage["content"]): string => {
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .filter((part): part is {type: "text"; text: string} => part.type === "text")
+      .map(part => part.text)
+      .join("\n")
+      .trim();
+  }
+  return "";
+};
+
+export type AssistantAgentOptions = {
+  allowedModules: string[];
+  task?: AiTask;
+  onToolStart?: (name: string) => void;
+  signal?: AbortSignal;
+};
+
+export type AssistantAgentResult =
+  | {type: "answer"; answer: string; charts: AiChartSpec[]; messages: OpenAIChatMessage[]}
+  | {
+      type: "write_proposal";
+      proposal: WriteProposal;
+      toolCallId: string;
+      charts: AiChartSpec[];
+      messages: OpenAIChatMessage[];
+    };
+
+const SYSTEM_PROMPT = [
+  "You are the restaurant's in-app assistant. You can answer questions using the read-only report tools,",
+  "and you can propose dish create/update changes using the propose_* tools.",
+  "The propose_* tools NEVER save anything by themselves — they only prepare a change for the user to review.",
+  "After calling a propose_* tool, stop and wait; do not call it again or assume it was applied.",
+  "For bulk changes, always call propose_* with every affected row included — the user will review each row",
+  "individually before confirming, so do not summarize or skip rows.",
+].join(" ");
+
+const buildToolset = (allowedModules: string[]) => {
+  const readTools = filterToolsByPermissions(AI_REPORT_TOOLS, allowedModules);
+  const writeTools = filterWriteToolsByPermissions(AI_WRITE_TOOLS, allowedModules);
+  return [...readTools, ...writeTools];
+};
+
+async function runLoop(
+  db: AssistantDbClient,
+  t: TFunc,
+  messages: OpenAIChatMessage[],
+  options: AssistantAgentOptions,
+): Promise<AssistantAgentResult> {
+  const tools = buildToolset(options.allowedModules);
+  const context: ExecuteToolContext = {charts: []};
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const response = await callOpenAIChat({messages, tools, task: options.task ?? "reporting"});
+    const choice = response.choices[0]?.message;
+
+    if (!choice) {
+      throw new Error("AI returned an empty response.");
+    }
+
+    if (!choice.tool_calls?.length) {
+      const answer = messageText(choice.content);
+      if (!answer) {
+        throw new Error("AI returned an empty response.");
+      }
+      messages.push(choice);
+      return {type: "answer", answer, charts: dedupeCharts(context.charts), messages};
+    }
+
+    messages.push(choice);
+
+    for (const toolCall of choice.tool_calls) {
+      const args = JSON.parse(toolCall.function.arguments || "{}") as Record<string, unknown>;
+      const name = toolCall.function.name;
+      options.onToolStart?.(name);
+
+      if (WRITE_TOOL_NAME_SET.has(name)) {
+        // Deny-by-default even if the model somehow calls a write tool that
+        // wasn't in the filtered toolset it was given (defense in depth —
+        // never trust "the model was only offered allowed tools").
+        if (!canUseWriteTool(name, options.allowedModules)) {
+          messages.push({
+            role: "tool",
+            tool_call_id: toolCall.id,
+            content: JSON.stringify({error: "Not permitted: missing permission for this write action."}),
+          });
+          continue;
+        }
+
+        // Build the proposal, then STOP — do not resolve this tool_call and
+        // do not continue the loop. The caller must show the preview and
+        // call resumeAiAssistantAgent() once the user confirms or cancels.
+        const proposal = await buildWriteProposal(name, args, {db, t});
+        return {type: "write_proposal", proposal, toolCallId: toolCall.id, charts: dedupeCharts(context.charts), messages};
+      }
+
+      try {
+        const result = await executeAiReportTool(db, name, args, context);
+        messages.push({role: "tool", tool_call_id: toolCall.id, content: JSON.stringify(result)});
+      } catch (err) {
+        messages.push({
+          role: "tool",
+          tool_call_id: toolCall.id,
+          content: JSON.stringify({error: err instanceof Error ? err.message : "Tool execution failed"}),
+        });
+      }
+    }
+  }
+
+  throw new Error("Assistant exceeded maximum tool iterations. Try a simpler request.");
+}
+
+/** Start a new turn from a user prompt. */
+export async function runAiAssistantAgent(
+  db: AssistantDbClient,
+  t: TFunc,
+  prompt: string,
+  options: AssistantAgentOptions,
+  history: OpenAIChatMessage[] = [],
+): Promise<AssistantAgentResult> {
+  const trimmed = prompt.trim();
+  if (!trimmed) {
+    throw new Error("Prompt is empty.");
+  }
+
+  const messages: OpenAIChatMessage[] = [
+    {role: "system", content: SYSTEM_PROMPT},
+    ...history,
+    {role: "user", content: trimmed},
+  ];
+
+  return runLoop(db, t, messages, options);
+}
+
+/**
+ * Resume a turn after a write_proposal result was shown to the user.
+ * `outcome` becomes the tool result for the pending proposal's tool_call_id,
+ * so the model can react ("Applied — 3 dishes created." / "Cancelled, as you asked.")
+ * without ever having been given the ability to trigger the write itself.
+ */
+export async function resumeAiAssistantAgent(
+  db: AssistantDbClient,
+  t: TFunc,
+  messages: OpenAIChatMessage[],
+  pendingToolCallId: string,
+  outcome: {confirmed: boolean; summary?: unknown; error?: string},
+  options: AssistantAgentOptions,
+): Promise<AssistantAgentResult> {
+  const content = outcome.confirmed
+    ? JSON.stringify({applied: true, summary: outcome.summary ?? null})
+    : JSON.stringify({applied: false, reason: outcome.error ?? "User cancelled this change."});
+
+  const next: OpenAIChatMessage[] = [
+    ...messages,
+    {role: "tool", tool_call_id: pendingToolCallId, content},
+  ];
+
+  return runLoop(db, t, next, options);
+}

--- a/src/lib/ai/tools/write-definitions.ts
+++ b/src/lib/ai/tools/write-definitions.ts
@@ -1,0 +1,83 @@
+import type {OpenAIToolDefinition} from "@/lib/openai.service.ts";
+
+/**
+ * Write tools for the AI assistant. Unlike AI_REPORT_TOOLS (read-only, executed
+ * immediately by executeAiReportTool), calling one of these NEVER writes to the
+ * database. It only builds a validated proposal for the user to review and
+ * explicitly confirm — see write-tools.ts / write-executor.ts / assistant-agent.ts.
+ */
+export const AI_WRITE_TOOLS: OpenAIToolDefinition[] = [
+  {
+    type: "function",
+    function: {
+      name: "propose_create_dishes",
+      description:
+        "Propose creating one or more new dishes/menu items. This does NOT save anything — " +
+        "it only prepares a preview for the user to review and confirm. Use for requests " +
+        "like 'add a dish called X at $9' or bulk additions from a list.",
+      parameters: {
+        type: "object",
+        properties: {
+          dishes: {
+            type: "array",
+            description: "One entry per dish to create.",
+            items: {
+              type: "object",
+              properties: {
+                name: {type: "string", description: "Dish/menu item name"},
+                number: {type: "string", description: "Internal item number; omit to auto-assign"},
+                priority: {type: "number", description: "Display sort priority", default: 0},
+                price: {type: "number", description: "Sale price"},
+                cost: {type: "number", description: "Cost price", default: 0},
+                categories: {
+                  type: "array",
+                  items: {type: "string"},
+                  description: "Menu category name(s). Unknown categories will be created — flagged in the preview.",
+                },
+                tax: {type: "string", description: "Tax name, if applicable"},
+              },
+              required: ["name", "price", "categories"],
+            },
+          },
+        },
+        required: ["dishes"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "propose_update_dishes",
+      description:
+        "Propose updating one or more existing dishes, matched by their item number. This does NOT " +
+        "save anything — it only prepares a preview for the user to review and confirm. Use for " +
+        "requests like 'raise the price of dish #12 to $10' or bulk price/category changes. " +
+        "Only include fields that should change; omitted fields are left as-is.",
+      parameters: {
+        type: "object",
+        properties: {
+          dishes: {
+            type: "array",
+            description: "One entry per dish to update.",
+            items: {
+              type: "object",
+              properties: {
+                number: {type: "string", description: "Item number of the dish to update (required to match the row)"},
+                name: {type: "string"},
+                priority: {type: "number"},
+                price: {type: "number"},
+                cost: {type: "number"},
+                categories: {type: "array", items: {type: "string"}},
+                tax: {type: "string"},
+              },
+              required: ["number"],
+            },
+          },
+        },
+        required: ["dishes"],
+      },
+    },
+  },
+];
+
+export const AI_WRITE_TOOL_NAMES = AI_WRITE_TOOLS.map(tool => tool.function.name);

--- a/src/lib/ai/tools/write-permissions.test.ts
+++ b/src/lib/ai/tools/write-permissions.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from "vitest";
+import {canUseWriteTool, filterWriteToolsByPermissions} from "@/lib/ai/tools/write-permissions.ts";
+import {filterToolsByPermissions} from "@/lib/ai/tools/permissions.ts";
+import {AI_WRITE_TOOLS} from "@/lib/ai/tools/write-definitions.ts";
+
+describe("canUseWriteTool", () => {
+  it("denies by default with no modules granted", () => {
+    expect(canUseWriteTool("propose_create_dishes", [])).toBe(false);
+  });
+
+  it("denies an unknown tool name (no module mapped)", () => {
+    expect(canUseWriteTool("propose_delete_everything", ["admin.dishes.create"])).toBe(false);
+  });
+
+  it("allows only when the exact matching admin leaf is granted", () => {
+    expect(canUseWriteTool("propose_create_dishes", ["admin.dishes.create"])).toBe(true);
+    expect(canUseWriteTool("propose_update_dishes", ["admin.dishes.create"])).toBe(false);
+    expect(canUseWriteTool("propose_update_dishes", ["admin.dishes.update"])).toBe(true);
+  });
+
+  it("does NOT treat a sibling admin.dishes leaf as sufficient", () => {
+    // admin.dishes.import must not silently imply create/update
+    expect(canUseWriteTool("propose_create_dishes", ["admin.dishes.import"])).toBe(false);
+  });
+
+  /**
+   * Regression test for the gap flagged during planning: permissions.ts's
+   * filterToolsByPermissions() treats "reports.ai" as a catch-all that grants
+   * every tool passed to it. If write tools were ever filtered through THAT
+   * function, any session with reports.ai (full AI report access, granted
+   * before write tools existed) would silently gain write access with no
+   * separate consent. Confirm that gap is real on the read-side filter, and
+   * confirm the write-side filter is immune to it.
+   */
+  it("reports.ai does not grant write tools (write filter has no catch-all)", () => {
+    const allowedModules = ["reports.ai"];
+
+    // Demonstrates the catch-all behavior filterToolsByPermissions has by
+    // design for read tools (this is intentional there, per permissions.ts).
+    const readCheckViaCatchAll = filterToolsByPermissions(AI_WRITE_TOOLS, allowedModules);
+    expect(readCheckViaCatchAll).toHaveLength(AI_WRITE_TOOLS.length); // catch-all would leak everything if reused
+
+    // The actual write-tool filter must reject the same input.
+    const allowed = filterWriteToolsByPermissions(AI_WRITE_TOOLS, allowedModules);
+    expect(allowed).toHaveLength(0);
+    expect(canUseWriteTool("propose_create_dishes", allowedModules)).toBe(false);
+  });
+
+  it("filterWriteToolsByPermissions only returns tools the modules explicitly cover", () => {
+    const allowed = filterWriteToolsByPermissions(AI_WRITE_TOOLS, ["admin.dishes.create"]);
+    expect(allowed.map(t => t.function.name)).toEqual(["propose_create_dishes"]);
+  });
+});

--- a/src/lib/ai/tools/write-permissions.ts
+++ b/src/lib/ai/tools/write-permissions.ts
@@ -1,0 +1,33 @@
+import type {OpenAIToolDefinition} from "@/lib/openai.service.ts";
+import {normalizeModules} from "@/lib/access.rules.ts";
+
+/**
+ * Maps write tool names to the exact admin permission leaf that gates the
+ * equivalent manual action in Manage > Dishes (see dishes/index.tsx).
+ * Reusing these leaves means an operator's existing dish permissions are
+ * exactly what governs the AI assistant too — no separate grant to configure.
+ *
+ * Deliberately a SEPARATE map/filter from tools/permissions.ts, not reused:
+ * filterToolsByPermissions() there treats `reports.ai` as a catch-all that
+ * grants every tool it filters. Read tools are safe under that catch-all
+ * (reports.ai is explicitly "full AI report access"). Writes are not — a
+ * session that only ever granted reports.ai never consented to the assistant
+ * creating/editing dishes. Write tools are therefore filtered strictly,
+ * deny-by-default, with no catch-all bypass of any kind.
+ */
+export const WRITE_TOOL_PERMISSION_MODULES: Record<string, string> = {
+  propose_create_dishes: "admin.dishes.create",
+  propose_update_dishes: "admin.dishes.update",
+};
+
+/** True only if allowedModules explicitly grants the module this tool needs. */
+export const canUseWriteTool = (toolName: string, allowedModules: string[]): boolean => {
+  const module = WRITE_TOOL_PERMISSION_MODULES[toolName];
+  if (!module) return false;
+  return normalizeModules(allowedModules).includes(module);
+};
+
+export const filterWriteToolsByPermissions = (
+  tools: OpenAIToolDefinition[],
+  allowedModules: string[],
+): OpenAIToolDefinition[] => tools.filter(tool => canUseWriteTool(tool.function.name, allowedModules));

--- a/src/lib/ai/tools/write-tools.test.ts
+++ b/src/lib/ai/tools/write-tools.test.ts
@@ -110,6 +110,45 @@ describe("buildWriteProposal", () => {
     ).toBe(true);
   });
 
+  it("propose_update_dishes: a partial patch (price only) is NOT blocked by name/categories required checks", async () => {
+    // dish.import.config's onImportRow requires name/price/categories for both
+    // create AND update — reused as-is, a partial update would incorrectly
+    // read as missing-required. The write-tools layer must merge onto the
+    // existing dish first so this proposal comes back clean.
+    const db: ImportDbLike = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes("FETCH categories, tax")) {
+          return [[{
+            id: "menu_item:1",
+            name: "Existing Dish",
+            number: "1",
+            priority: 0,
+            price: 9,
+            cost: 3,
+            categories: [{id: "category:1", name: "Pizza"}],
+            tax: null,
+          }]];
+        }
+        if (sql.includes("category")) return [[{id: "category:1", name: "Pizza"}]];
+        if (sql.includes("tax")) return [[]];
+        return [[]];
+      }),
+      create: vi.fn(async () => { throw new Error("must never write during proposal build"); }),
+      insert: vi.fn(async () => { throw new Error("must never write during proposal build"); }),
+      merge: vi.fn(async () => { throw new Error("must never write during proposal build"); }),
+    };
+
+    const proposal = await buildWriteProposal(
+      "propose_update_dishes",
+      {dishes: [{number: "1", price: 12.5}]}, // only price supplied
+      {db, t},
+    );
+
+    expect(proposal.hasBlockingErrors).toBe(false);
+    expect(proposal.records[0].values.name).toBe("Existing Dish"); // fell back to existing
+    expect(proposal.records[0].values.price).toBe(12.5); // AI's change applied
+  });
+
   it("rejects unknown tool names", async () => {
     const db = makeDb();
     await expect(

--- a/src/lib/ai/tools/write-tools.test.ts
+++ b/src/lib/ai/tools/write-tools.test.ts
@@ -1,0 +1,119 @@
+import {describe, expect, it, vi} from "vitest";
+import {buildWriteProposal} from "@/lib/ai/tools/write-tools.ts";
+import type {ImportDbLike} from "@/lib/data-import/types.ts";
+
+const t = (key: string, options?: any) => options?.defaultValue ?? key;
+
+/**
+ * `create`/`insert`/`merge` throw if called — proves buildWriteProposal
+ * never writes to the database, only `query` (reference lookups) is used.
+ */
+const makeDb = (categoryRows: Array<{id: string; name: string}> = [{id: "categories:1", name: "Pizza"}]): ImportDbLike => ({
+  query: vi.fn(async (sql: string) => {
+    if (sql.includes("categories")) return [categoryRows];
+    if (sql.includes("taxes")) return [[]];
+    return [[]];
+  }),
+  create: vi.fn(async () => {
+    throw new Error("buildWriteProposal must never call db.create");
+  }),
+  insert: vi.fn(async () => {
+    throw new Error("buildWriteProposal must never call db.insert");
+  }),
+  merge: vi.fn(async () => {
+    throw new Error("buildWriteProposal must never call db.merge");
+  }),
+});
+
+describe("buildWriteProposal", () => {
+  it("propose_create_dishes: builds a clean proposal for a valid dish, no db writes", async () => {
+    const db = makeDb();
+    const proposal = await buildWriteProposal(
+      "propose_create_dishes",
+      {dishes: [{name: "Margherita", price: 9, categories: ["Pizza"]}]},
+      {db, t},
+    );
+
+    expect(proposal.mode).toBe("create");
+    expect(proposal.configId).toBe("dishes");
+    expect(proposal.records).toHaveLength(1);
+    expect(proposal.hasBlockingErrors).toBe(false);
+    expect(db.create).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.merge).not.toHaveBeenCalled();
+  });
+
+  it("propose_create_dishes: flags missing required fields as blocking, still no db writes", async () => {
+    const db = makeDb();
+    // no price, no categories
+    const proposal = await buildWriteProposal(
+      "propose_create_dishes",
+      {dishes: [{name: "Mystery item"}]},
+      {db, t},
+    );
+
+    expect(proposal.hasBlockingErrors).toBe(true);
+    const issues = proposal.records[0].issues;
+    expect(issues.some(i => i.field === "price" && i.severity === "error")).toBe(true);
+    expect(issues.some(i => i.field === "categories" && i.severity === "error")).toBe(true);
+    expect(db.create).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.merge).not.toHaveBeenCalled();
+  });
+
+  it("propose_create_dishes: unknown category is flagged for create, not silently resolved", async () => {
+    const db = makeDb([{id: "categories:1", name: "Pizza"}]);
+    const proposal = await buildWriteProposal(
+      "propose_create_dishes",
+      {dishes: [{name: "Sushi Roll", price: 12, categories: ["Sushi"]}]},
+      {db, t},
+    );
+
+    const categoryValue = proposal.records[0].values.categories;
+    expect(categoryValue[0].create).toBe(true);
+    expect(categoryValue[0].id).toBeUndefined();
+    // Deliberately create:true, not an issue: validateRecord() only re-raises
+    // unresolved_reference when a ref is NOT resolved and NOT flagged create
+    // (see validate.ts) — a "will be created" ref is a valid, non-blocking
+    // state. The preview UI's own signal is the `create` flag itself
+    // (rendered as "(new)" — see write-proposal-preview.tsx's formatCell).
+    expect(proposal.hasBlockingErrors).toBe(false);
+    expect(proposal.records[0].issues.some(i => i.severity === "error")).toBe(false);
+  });
+
+  it("propose_update_dishes: builds an update-mode proposal keyed on number", async () => {
+    const db = makeDb();
+    const proposal = await buildWriteProposal(
+      "propose_update_dishes",
+      {dishes: [{number: "42", price: 11}]},
+      {db, t},
+    );
+
+    expect(proposal.mode).toBe("update");
+    expect(proposal.records[0].values.number).toBe("42");
+    expect(db.create).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.merge).not.toHaveBeenCalled();
+  });
+
+  it("propose_update_dishes: missing match field (number) is blocking in the preview, not just at commit", async () => {
+    const db = makeDb();
+    const proposal = await buildWriteProposal(
+      "propose_update_dishes",
+      {dishes: [{price: 11}]}, // no `number` — nothing to match against
+      {db, t},
+    );
+
+    expect(proposal.hasBlockingErrors).toBe(true);
+    expect(
+      proposal.records[0].issues.some(i => i.field === "number" && i.severity === "error"),
+    ).toBe(true);
+  });
+
+  it("rejects unknown tool names", async () => {
+    const db = makeDb();
+    await expect(
+      buildWriteProposal("propose_delete_everything", {}, {db, t}),
+    ).rejects.toThrow(/Unknown write tool/);
+  });
+});

--- a/src/lib/ai/tools/write-tools.ts
+++ b/src/lib/ai/tools/write-tools.ts
@@ -1,0 +1,118 @@
+import type {ImportConfiguration, ImportDbLike, ImportRecord} from "@/lib/data-import/types.ts";
+import {normalizeRecords} from "@/lib/data-import/normalize.ts";
+import {validateRecords} from "@/lib/data-import/validate.ts";
+import {createDishImportConfig} from "@/components/settings/dishes/dish.import.config.ts";
+import type {CsvImportMode} from "@/utils/csv-import.ts";
+
+export type TFunc = (key: string, options?: any) => string;
+
+export type WriteProposal = {
+  /** Stable id for correlating a confirm/cancel click back to this proposal. */
+  proposalId: string;
+  toolName: string;
+  configId: string;
+  entityLabel: string;
+  mode: CsvImportMode;
+  records: ImportRecord[];
+  /** True if any record has a blocking (severity: "error") issue — commit must be disabled. */
+  hasBlockingErrors: boolean;
+};
+
+let proposalSeq = 0;
+const nextProposalId = () => `wp_${Date.now()}_${proposalSeq++}`;
+
+const recordHasError = (record: ImportRecord) =>
+  record.issues.some(issue => issue.severity === "error");
+
+/**
+ * validateRecord() (validate.ts) only checks ImportField.required — match
+ * fields like dish.import.config's "number" aren't marked required (it's
+ * optional/auto-assigned on create), so a missing match value on an UPDATE
+ * row sails through validation clean and only fails later, per-row, inside
+ * runImport's assertCsvMatchValues (write-executor.ts's commit path) — after
+ * the user already confirmed a preview that showed no errors. Flag it here
+ * instead, at proposal time, so the preview is the actual ground truth.
+ */
+function flagMissingMatchFields(config: ImportConfiguration, mode: CsvImportMode, records: ImportRecord[]): void {
+  if (mode === "create") return;
+  const matchFields = config.matchFields ?? [];
+  if (matchFields.length === 0) return;
+
+  for (const record of records) {
+    for (const field of matchFields) {
+      const value = record.values[field];
+      const empty = value === null || value === undefined || String(value).trim() === "";
+      if (empty) {
+        record.issues.push({
+          field,
+          code: "required",
+          severity: "error",
+          message: `"${field}" is required to match the row to update`,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Builds a write proposal from raw AI tool-call args: normalize -> resolve
+ * references -> validate. Never writes to the database. Mirrors the same
+ * pipeline runImportPipeline/revalidateImportRecords use for file imports
+ * (normalizeRecords + validateRecords({resolveRefs: true})), so an AI-driven
+ * proposal goes through identical validation to a spreadsheet import.
+ */
+async function buildProposal(
+  toolName: string,
+  config: ImportConfiguration,
+  mode: CsvImportMode,
+  rawRecords: Array<Record<string, unknown>>,
+): Promise<WriteProposal> {
+  const normalized = normalizeRecords(config, rawRecords);
+  const records = await validateRecords(config, normalized, {resolveRefs: true});
+  flagMissingMatchFields(config, mode, records);
+
+  return {
+    proposalId: nextProposalId(),
+    toolName,
+    configId: config.id,
+    entityLabel: config.entityLabel,
+    mode,
+    records,
+    hasBlockingErrors: records.some(recordHasError),
+  };
+}
+
+export type BuildWriteProposalOptions = {
+  db: ImportDbLike;
+  t: TFunc;
+};
+
+/**
+ * Dispatch for AI write tool calls. Only ever returns a WriteProposal —
+ * no case here may call runImport / onImportRow / db writes. That happens
+ * exclusively in write-executor.ts, after explicit user confirmation.
+ */
+export const buildWriteProposal = async (
+  toolName: string,
+  args: Record<string, unknown>,
+  options: BuildWriteProposalOptions,
+): Promise<WriteProposal> => {
+  const {db, t} = options;
+
+  switch (toolName) {
+    case "propose_create_dishes": {
+      const config = createDishImportConfig({db, t});
+      const dishes = Array.isArray(args.dishes) ? args.dishes : [];
+      return buildProposal(toolName, config, "create", dishes as Array<Record<string, unknown>>);
+    }
+
+    case "propose_update_dishes": {
+      const config = createDishImportConfig({db, t});
+      const dishes = Array.isArray(args.dishes) ? args.dishes : [];
+      return buildProposal(toolName, config, "update", dishes as Array<Record<string, unknown>>);
+    }
+
+    default:
+      throw new Error(`Unknown write tool: ${toolName}`);
+  }
+};

--- a/src/lib/ai/tools/write-tools.ts
+++ b/src/lib/ai/tools/write-tools.ts
@@ -2,6 +2,7 @@ import type {ImportConfiguration, ImportDbLike, ImportRecord} from "@/lib/data-i
 import {normalizeRecords} from "@/lib/data-import/normalize.ts";
 import {validateRecords} from "@/lib/data-import/validate.ts";
 import {createDishImportConfig} from "@/components/settings/dishes/dish.import.config.ts";
+import {Tables} from "@/api/db/tables.ts";
 import type {CsvImportMode} from "@/utils/csv-import.ts";
 
 export type TFunc = (key: string, options?: any) => string;
@@ -52,6 +53,65 @@ function flagMissingMatchFields(config: ImportConfiguration, mode: CsvImportMode
       }
     }
   }
+}
+
+/**
+ * dish.import.config.ts's onImportRow always requires name/price/categories,
+ * for BOTH create and update — it was built for full-row CSV imports, never
+ * for partial "just change the price" updates. Reusing it as-is for update
+ * mode would either (a) block every partial update in the preview as
+ * missing-required, or worse (b) pass preview clean by suppressing that
+ * check and then still throw at commit inside onImportRow itself (same
+ * "preview isn't ground truth" class of bug already fixed once for match
+ * fields). Real fix: fetch the existing dish and merge the AI's partial
+ * patch onto it BEFORE normalize/validate, so an omitted field falls back
+ * to its current value instead of reading as missing. dish.import.config.ts
+ * and the shared import pipeline are untouched — this is AI-write-path-only.
+ */
+async function fetchExistingDishRaw(
+  db: ImportDbLike,
+  number: string,
+): Promise<Record<string, unknown> | null> {
+  const [rows] = await db.query(
+    `SELECT * FROM ${Tables.dishes} WHERE number = $number AND deleted_at = none LIMIT 1 FETCH categories, tax`,
+    {number},
+  );
+  const dish = rows?.[0];
+  if (!dish) return null;
+
+  const categories = Array.isArray(dish.categories)
+    ? dish.categories
+        .filter((c: any) => c && c.id)
+        .map((c: any) => ({label: String(c.name ?? ""), id: String(c.id)}))
+    : [];
+  const tax = dish.tax && dish.tax.id
+    ? {label: String(dish.tax.name ?? ""), id: String(dish.tax.id)}
+    : undefined;
+
+  return {
+    name: dish.name,
+    number: dish.number,
+    priority: dish.priority,
+    price: dish.price,
+    cost: dish.cost,
+    categories,
+    tax,
+  };
+}
+
+async function mergeUpdatePatchesWithExisting(
+  db: ImportDbLike,
+  patches: Array<Record<string, unknown>>,
+): Promise<Array<Record<string, unknown>>> {
+  return Promise.all(patches.map(async (patch) => {
+    const number = patch.number !== undefined && patch.number !== null ? String(patch.number).trim() : "";
+    if (!number) return patch; // no match key — flagMissingMatchFields will catch this
+
+    const existing = await fetchExistingDishRaw(db, number);
+    if (!existing) return patch; // no such dish — let it fail honestly, nothing to merge from
+
+    return {...existing, ...patch};
+  }));
 }
 
 /**
@@ -108,8 +168,9 @@ export const buildWriteProposal = async (
 
     case "propose_update_dishes": {
       const config = createDishImportConfig({db, t});
-      const dishes = Array.isArray(args.dishes) ? args.dishes : [];
-      return buildProposal(toolName, config, "update", dishes as Array<Record<string, unknown>>);
+      const patches = Array.isArray(args.dishes) ? args.dishes as Array<Record<string, unknown>> : [];
+      const merged = await mergeUpdatePatchesWithExisting(db, patches);
+      return buildProposal(toolName, config, "update", merged);
     }
 
     default:

--- a/src/lib/ai/write-executor.test.ts
+++ b/src/lib/ai/write-executor.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, it, vi} from "vitest";
+import {buildWriteProposal} from "@/lib/ai/tools/write-tools.ts";
+import {commitWriteProposal} from "@/lib/ai/write-executor.ts";
+import type {ImportDbLike} from "@/lib/data-import/types.ts";
+
+const t = (key: string, options?: any) => options?.defaultValue ?? key;
+
+const makeDb = (): ImportDbLike & {creates: any[]; inserts: any[]} => {
+  const creates: any[] = [];
+  const inserts: any[] = [];
+  return {
+    creates,
+    inserts,
+    query: vi.fn(async (sql: string) => {
+      if (sql.includes("categories")) return [[{id: "categories:1", name: "Pizza"}]];
+      if (sql.includes("taxes")) return [[]];
+      if (sql.includes("menu_item")) return [[]]; // number sequence probe (Tables.dishes = 'menu_item')
+      return [[]];
+    }),
+    create: vi.fn(async (table: string, payload: any) => {
+      creates.push({table, payload});
+      return [{id: `${table}:new`, ...payload}];
+    }),
+    insert: vi.fn(async (table: string, payload: any) => {
+      inserts.push({table, payload});
+      return [{id: `${table}:new`, ...payload}];
+    }),
+    merge: vi.fn(async () => [{}]),
+  };
+};
+
+describe("commitWriteProposal", () => {
+  it("only writes what was in the proposal, once, on explicit call", async () => {
+    const db = makeDb();
+    const proposal = await buildWriteProposal(
+      "propose_create_dishes",
+      {dishes: [{name: "Margherita", price: 9, categories: ["Pizza"]}]},
+      {db, t},
+    );
+
+    // Nothing written yet — building the proposal must not have persisted anything.
+    expect(db.creates).toHaveLength(0);
+    expect(db.inserts).toHaveLength(0);
+
+    const summary = await commitWriteProposal(db, t, proposal);
+
+    expect(summary.imported).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(db.inserts).toHaveLength(1);
+    expect(db.inserts[0].table).toBe("menu_item"); // Tables.dishes = 'menu_item'
+    expect(db.inserts[0].payload.name).toBe("Margherita");
+  });
+
+  it("skips (does not write) rows with blocking errors, reports them as failed", async () => {
+    const db = makeDb();
+    const proposal = await buildWriteProposal(
+      "propose_create_dishes",
+      {dishes: [
+        {name: "Good Dish", price: 9, categories: ["Pizza"]},
+        {name: "Bad Dish"}, // missing price + categories -> blocking
+      ]},
+      {db, t},
+    );
+
+    expect(proposal.hasBlockingErrors).toBe(true);
+    const summary = await commitWriteProposal(db, t, proposal);
+
+    expect(summary.imported).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(db.inserts).toHaveLength(1); // the bad row never reached db.insert
+    expect(db.inserts[0].payload.name).toBe("Good Dish");
+  });
+
+  it("rejects proposals for configs it has no executor for", async () => {
+    const db = makeDb();
+    await expect(
+      commitWriteProposal(db, t, {
+        proposalId: "x",
+        toolName: "propose_create_widgets",
+        configId: "widgets",
+        entityLabel: "Widget",
+        mode: "create",
+        records: [],
+        hasBlockingErrors: false,
+      }),
+    ).rejects.toThrow(/No write executor registered/);
+  });
+});

--- a/src/lib/ai/write-executor.ts
+++ b/src/lib/ai/write-executor.ts
@@ -1,0 +1,35 @@
+import type {ImportDbLike} from "@/lib/data-import/types.ts";
+import type {ImportSummary} from "@/lib/data-import/types.ts";
+import {runImport} from "@/lib/data-import/run-import.ts";
+import {createDishImportConfig} from "@/components/settings/dishes/dish.import.config.ts";
+import type {TFunc, WriteProposal} from "@/lib/ai/tools/write-tools.ts";
+
+/**
+ * The ONLY function in the write path allowed to persist changes. Call this
+ * exclusively from the widget's explicit Confirm action, after the user has
+ * reviewed the full line-by-line proposal (WriteProposal.records) — never
+ * from the assistant chat loop automatically.
+ *
+ * Records with blocking errors are skipped by runImport itself (counted as
+ * failed), so it's still safe to call even if the caller forgot to check
+ * hasBlockingErrors — but the widget should block the Confirm button on it
+ * so the user isn't surprised by partial application.
+ */
+export async function commitWriteProposal(
+  db: ImportDbLike,
+  t: TFunc,
+  proposal: WriteProposal,
+  options: {signal?: AbortSignal; onProgress?: (current: number, total: number) => void} = {},
+): Promise<ImportSummary> {
+  if (proposal.configId !== "dishes") {
+    throw new Error(`No write executor registered for config "${proposal.configId}"`);
+  }
+
+  const config = createDishImportConfig({db, t});
+
+  return runImport(config, proposal.records, {
+    mode: proposal.mode,
+    signal: options.signal,
+    onProgress: options.onProgress,
+  });
+}


### PR DESCRIPTION
Step 1/2 of a phased plan agreed with the maintainer over email: shared assistant core plus a global widget, then dish write tools that reuse the existing Import config machinery.

The existing read only Reports > AI loop (`agent.ts`, `executor.ts`) is untouched and still works as before. This adds a separate write path instead of modifying it. `write-tools.ts` builds a validated proposal (normalize, resolve references, validate, reusing `dish.import.config.ts` and `run-import.ts` as is) and never writes to the database. `write-executor.ts`'s `commitWriteProposal()` is the only function allowed to call `runImport()`, and it only fires on explicit user confirmation.

Every proposed row shows in a full line by line preview, virtualized with `react-window` (already a project dependency), with no summarizing.

Permissions reuse the existing `admin.dishes.create` and `admin.dishes.update` leaves, the same ones Manage > Dishes already enforces, filtered strictly. This is deliberately not the `reports.ai` catch all that read tools use, so full report access does not silently imply write access.

The floating widget is mounted globally in `app.tsx` next to the existing `GlobalDeliveryOrderPopup`.

There are 16 new tests, 3 of them written and proven as regressions (red before the fix, green after). The full suite passes 201 of 202 (the one failure is a pre-existing, unrelated perf flake). Typecheck output is byte identical to baseline.

Note on scope: dishes was my inference from your earlier examples, not something you explicitly picked among the five steps. Happy to redirect to a different screen first if that's not what you had in mind.
